### PR TITLE
set cache-control header for static/

### DIFF
--- a/server.go
+++ b/server.go
@@ -249,6 +249,6 @@ func staticHandler(c echo.Context) error {
 	}
 	defer file.Close()
 
-	// ファイルの内容を返す
+	c.Response().Header().Set("cache-control", "public, max-age=86400")
 	return c.Stream(http.StatusOK, "text/css", file)
 }


### PR DESCRIPTION
This pull request includes a change to the `staticHandler` function in the `server.go` file to improve caching for static files.

* [`server.go`](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6L252-R252): Added a `cache-control` header to the response in the `staticHandler` function to set caching for one day.